### PR TITLE
Component cleanup: shared state, unit toggle, Cesium modularization

### DIFF
--- a/client/src/components/CesiumMap.jsx
+++ b/client/src/components/CesiumMap.jsx
@@ -11,88 +11,17 @@ import {
     Ion
 } from '@cesium/engine';
 import UnitToggle from './UnitToggle';
+import CesiumWaypointEntity from './CesiumWaypointEntity';
+import useCesiumInit from '../hooks/useCesiumInit';
+
+
 
 Ion.defaultAccessToken = import.meta.env.VITE_CESIUM_TOKEN;
 
-export default function CesiumMap() {
+export default function CesiumMap({ waypoints, setWaypoints, unitSystem, setUnitSystem }) {
     const viewerRef = useRef();
-    const [viewer, setViewer] = useState(null);
-    const [terrainProvider, setTerrainProvider] = useState(null);
-    const [waypoints, setWaypoints] = useState([]);
-    const [unitSystem, setUnitSystem] = useState('metric');
-
-
-    // ✅ Load Cesium terrain once
-    useEffect(() => {
-        const loadTerrain = async () => {
-            try {
-                if (!Ion.defaultAccessToken) {
-                    console.error("❌ Cesium Ion token not found.");
-                    return;
-                }
-
-                const terrain = await CesiumTerrainProvider.fromIonAssetId(1);
-                await terrain.readyPromise;
-
-                console.log("✅ Terrain loaded");
-                setTerrainProvider(terrain);
-            } catch (err) {
-                console.error("❌ Terrain loading failed:", err);
-            }
-        };
-
-        loadTerrain();
-    }, []);
-
-    // ✅ Set default camera view once both viewer + terrain are ready
-    useEffect(() => {
-        const setCameraView = async () => {
-            if (!viewer || !terrainProvider) {
-                console.log("⏳ Waiting on viewer or terrain...");
-                return;
-            }
-
-            await terrainProvider.readyPromise;
-            console.log("📍 Setting default camera view...");
-
-            viewer.scene.camera.setView({
-                destination: Cartesian3.fromDegrees(
-                    -122.44547431638014,
-                    37.611176246617994,
-                    17363.451336429982
-                ),
-                orientation: {
-                    heading: CesiumMath.toRadians(0.0),
-                    pitch: CesiumMath.toRadians(-45.0),
-                    roll: 0.0,
-                },
-            });
-
-            viewer.scene.camera.defaultViewFactor = 0;
-            viewer.scene.camera.defaultViewRectangle = undefined;
-        };
-
-        setCameraView();
-    }, [viewer, terrainProvider]);
-
-    // ✅ Fallback if onReady doesn’t fire
-    useEffect(() => {
-        const tryAttachViewer = () => {
-            if (!viewer && viewerRef.current?.cesiumElement) {
-                console.log("🛠 Manually attaching viewer");
-                setViewer(viewerRef.current.cesiumElement);
-            }
-        };
-
-        const interval = setInterval(tryAttachViewer, 200);
-        return () => clearInterval(interval);
-    }, [viewer]);
-
-    // ✅ Optional viewer init hook (may not always fire reliably)
-    const handleViewerReady = (cesiumViewer) => {
-        console.log("🚀 onReady fired — viewer:", cesiumViewer);
-        setViewer(cesiumViewer);
-    };
+    const { viewer, terrainProvider } = useCesiumInit(viewerRef);
+    
 
     // ✅ Handle clicks for waypoints
     const handleClick = async (movement) => {
@@ -130,41 +59,11 @@ export default function CesiumMap() {
                     animation={false}
                     view={null}
                 >
-                    {waypoints.map((wp, i) => (
-                        <Entity
-                            key={i}
-                            name={`Waypoint ${i + 1}`}
-                            position={Cartesian3.fromDegrees(wp.lng, wp.lat, wp.alt)}
-                            point={{
-                                pixelSize: 14,
-                                color: Color.RED.withAlpha(0.95),
-                                outlineColor: Color.WHITE,
-                                outlineWidth: 2,
-                                disableDepthTestDistance: Number.POSITIVE_INFINITY,
-                            }}
-                            label={{
-                                text:
-                                    unitSystem === 'metric'
-                                        ? `${wp.alt.toFixed(1)} m`
-                                        : `${(wp.alt * 3.28084).toFixed(1)} ft`,
-                                font: 'bold 16px sans-serif',
-                                fillColor: Color.WHITE,
-                                outlineColor: Color.BLACK,
-                                outlineWidth: 4,
-                                showBackground: true,
-                                backgroundColor: Color.BLACK.withAlpha(0.6),
-                                verticalOrigin: 1,
-                                pixelOffset: new Cartesian3(0, -35, 0),
-                                scale: 1.2,
-                                distanceDisplayCondition: new DistanceDisplayCondition(0.0, 10000.0),
-                                disableDepthTestDistance: Number.POSITIVE_INFINITY,
-                            }}
-                            description={`Lat: ${wp.lat.toFixed(5)}, Lng: ${wp.lng.toFixed(5)}, Alt: ${unitSystem === 'metric'
-                                    ? `${wp.alt.toFixed(2)}m`
-                                    : `${(wp.alt * 3.28084).toFixed(2)}ft`
-                                }`}
-                        />
-                    ))}
+                    {waypoints.map((wp, i) => {
+                        return (
+                            <CesiumWaypointEntity key={i} wp={wp} unitSystem={unitSystem} index={i} />
+                        )
+                    })}
                 </Viewer>
                 <div style={{
                     position: 'absolute',

--- a/client/src/components/CesiumWaypointEntity.jsx
+++ b/client/src/components/CesiumWaypointEntity.jsx
@@ -1,0 +1,48 @@
+import { Entity } from 'resium';
+import {
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+} from '@cesium/engine';
+
+export default function CesiumWaypointEntity({ wp, unitSystem, index }) {
+  const altitude = wp.alt ?? 0;
+
+  return (
+    <Entity
+      name={`Waypoint ${index + 1}`}
+      position={Cartesian3.fromDegrees(wp.lng, wp.lat, altitude)}
+      point={{
+        pixelSize: 14,
+        color: Color.RED.withAlpha(0.95),
+        outlineColor: Color.WHITE,
+        outlineWidth: 2,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      }}
+      label={{
+        text:
+          unitSystem === 'metric'
+            ? `${altitude.toFixed(1)} m`
+            : `${(altitude * 3.28084).toFixed(1)} ft`,
+        font: 'bold 16px sans-serif',
+        fillColor: Color.WHITE,
+        outlineColor: Color.BLACK,
+        outlineWidth: 4,
+        showBackground: true,
+        backgroundColor: Color.BLACK.withAlpha(0.6),
+        verticalOrigin: 1,
+        pixelOffset: new Cartesian3(0, -35, 0),
+        scale: 1.2,
+        distanceDisplayCondition: new DistanceDisplayCondition(0.0, 10000.0),
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      }}
+      description={`Lat: ${wp.lat.toFixed(5)}, Lng: ${wp.lng.toFixed(
+        5
+      )}, Alt: ${
+        unitSystem === 'metric'
+          ? `${altitude.toFixed(2)}m`
+          : `${(altitude * 3.28084).toFixed(2)}ft`
+      }`}
+    />
+  );
+}

--- a/client/src/components/Map.jsx
+++ b/client/src/components/Map.jsx
@@ -11,7 +11,7 @@ import DroneController from './DroneController.jsx';
 import LogPanel from './LogPanel.jsx';
 import { GeoJSON } from 'react-leaflet';
 import MetricsPanel from './MetricsPanel.jsx';
-
+import UnitToggle from './UnitToggle.jsx';
 
 
 
@@ -22,9 +22,8 @@ const droneIcon = new L.Icon({
 });
 
 
-export default function MapComponent() {
+export default function MapComponent({ waypoints, setWaypoints, unitSystem, setUnitSystem }) {
   const startPosition = [37.7749, -122.4194]; // SF coordinates
-  const [waypoints, setWaypoints] = useState([]); //waypoints is an array with each element containing an object of lat and lng
   const [dronePosition, setDronePosition] = useState([37.7749, -122.4194]);  // home base
   const [logs, setLogs] = useState([]);
 
@@ -55,7 +54,7 @@ export default function MapComponent() {
           attribution='&copy; OpenStreetMap contributors'
         />
         <WaypointManager
-          waypoints={waypoints} setWaypoints={setWaypoints}
+          waypoints={waypoints} setWaypoints={setWaypoints} unitSystem={unitSystem}
         />
 
         <Marker position={dronePosition} icon={droneIcon}>
@@ -66,8 +65,23 @@ export default function MapComponent() {
 
       </MapContainer>
       <LogPanel logs={logs} clearLogs={clearLogs} />
-      <DroneController waypoints={waypoints} setDronePosition={setDronePosition} dronePosition={dronePosition} logs={logs} setLogs={setLogs} handleClearWaypoints={clearWaypoints} />      
+      <DroneController waypoints={waypoints} setDronePosition={setDronePosition} dronePosition={dronePosition} logs={logs} setLogs={setLogs} handleClearWaypoints={clearWaypoints} />
       <MetricsPanel waypoints={waypoints} setWaypoints={setWaypoints} setLogs={setLogs} />
+      <div
+        style={{
+          position: 'absolute',
+          top: '12px',
+          left: '12px',
+          backgroundColor: 'white',
+          padding: '6px 10px',
+          borderRadius: '4px',
+          boxShadow: '0 1px 6px rgba(0, 0, 0, 0.2)',
+          zIndex: 999,
+        }}
+      >
+        <UnitToggle unitSystem={unitSystem} onChange={setUnitSystem} />
+      </div>
+
 
 
 

--- a/client/src/components/MissionPlannerWrapper.jsx
+++ b/client/src/components/MissionPlannerWrapper.jsx
@@ -1,11 +1,18 @@
 import { useState } from 'react';
-import MapComponent from './Map.jsx';         // your Leaflet map
-import CesiumMap from './CesiumMap'; // your 3D globe
+import MapComponent from './Map.jsx';
+import CesiumMap from './CesiumMap';
 import 'leaflet/dist/leaflet.css';
 
 export default function MissionPlannerWrapper() {
   const [viewMode, setViewMode] = useState("2d");
-    console.log(viewMode);
+
+  // ✅ Shared state (lifted)
+  const [waypoints, setWaypoints] = useState([]);
+  const [unitSystem, setUnitSystem] = useState("metric");
+
+  console.log("🔁 Rendering view:", viewMode);
+console.log("📌 Waypoints count:", waypoints.length);
+
 
 
   return (
@@ -15,7 +22,21 @@ export default function MissionPlannerWrapper() {
         <button onClick={() => setViewMode("3d")}>3D View</button>
       </div>
 
-      {viewMode === "2d" ? <MapComponent /> : <CesiumMap />}
+      {viewMode === "2d" ? (
+        <MapComponent
+          waypoints={waypoints}
+          setWaypoints={setWaypoints}
+          unitSystem={unitSystem}
+          setUnitSystem={setUnitSystem}
+        />
+      ) : (
+        <CesiumMap
+          waypoints={waypoints}
+          setWaypoints={setWaypoints}
+          unitSystem={unitSystem}
+          setUnitSystem={setUnitSystem}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/WaypointManager.jsx
+++ b/client/src/components/WaypointManager.jsx
@@ -6,9 +6,7 @@ import WaypointMarker from './WaypointMarker.jsx';
 
 
 
-export default function WaypointManager({waypoints, setWaypoints}) {
-
- 
+export default function WaypointManager({ waypoints, setWaypoints, unitSystem }) {
 
   useMapEvents({
     click(e) {
@@ -20,13 +18,16 @@ export default function WaypointManager({waypoints, setWaypoints}) {
   return (
     <>
       {
-        waypoints.map((point, index) => {
+        waypoints.map((wp, i) => {
           return (
             <WaypointMarker
-              key={index}
-              lat={point.lat}
-              lng={point.lng}
-              index={index}
+              key={i}
+              lat={wp.lat}
+              lng={wp.lng}
+              alt={wp.alt}
+              index={i}
+              unitSystem={unitSystem}
+
             />
           )
         })

--- a/client/src/components/WaypointMarker.jsx
+++ b/client/src/components/WaypointMarker.jsx
@@ -1,11 +1,21 @@
-//use this to create the WaypointMarker. Props are passed down from waypoint manager
-
 import { Marker, Popup } from 'react-leaflet';
 
-export default function WaypointMarker({ lat, lng, index }) {
+export default function WaypointMarker({ lat, lng, alt, index, unitSystem }) {
+  const altitude = alt ?? 0;
+  const formattedAlt =
+    unitSystem === 'metric'
+      ? `${altitude.toFixed(1)} m`
+      : `${(altitude * 3.28084).toFixed(1)} ft`;
+
   return (
     <Marker position={[lat, lng]}>
-      <Popup>Waypoint {index + 1}</Popup>
+      <Popup>
+        <div>
+          <strong>Waypoint {index + 1}</strong>
+          <br />
+          Alt: {formattedAlt}
+        </div>
+      </Popup>
     </Marker>
   );
 }

--- a/client/src/hooks/useCesiumInit.js
+++ b/client/src/hooks/useCesiumInit.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { CesiumTerrainProvider, Ion, Math as CesiumMath, Cartesian3 } from '@cesium/engine';
+
+Ion.defaultAccessToken = import.meta.env.VITE_CESIUM_TOKEN;
+
+export default function useCesiumInit(viewerRef) {
+  const [terrainProvider, setTerrainProvider] = useState(null);
+  const [viewer, setViewer] = useState(null);
+
+  useEffect(() => {
+    const loadTerrain = async () => {
+      try {
+        const terrain = await CesiumTerrainProvider.fromIonAssetId(1);
+        await terrain.readyPromise;
+        console.log("✅ Terrain loaded");
+        setTerrainProvider(terrain);
+      } catch (err) {
+        console.error("❌ Terrain failed:", err);
+      }
+    };
+    loadTerrain();
+  }, []);
+
+  useEffect(() => {
+    const tryAttachViewer = () => {
+      if (!viewer && viewerRef.current?.cesiumElement) {
+        console.log("🛠 Manually attaching viewer");
+        setViewer(viewerRef.current.cesiumElement);
+      }
+    };
+
+    const interval = setInterval(tryAttachViewer, 200);
+    return () => clearInterval(interval);
+  }, [viewer]);
+
+  useEffect(() => {
+    if (!viewer || !terrainProvider) return;
+
+    viewer.scene.camera.setView({
+      destination: Cartesian3.fromDegrees(
+        -122.44547431638014,
+        37.611176246617994,
+        17363.451336429982
+      ),
+      orientation: {
+        heading: CesiumMath.toRadians(0.0),
+        pitch: CesiumMath.toRadians(-45.0),
+        roll: 0.0,
+      },
+    });
+  }, [viewer, terrainProvider]);
+
+  return { viewer, terrainProvider };
+}


### PR DESCRIPTION
This PR includes:
- Lifted `waypoints` and `unitSystem` state to `MissionPlannerWrapper`
- Reusable `UnitToggle` now works in both 2D and 3D
- Created `CesiumWaypointEntity` to encapsulate Cesium marker logic
- Added `useCesiumInit()` hook to handle viewer, terrain, and camera init
- Altitude fallback now prevents rendering errors
